### PR TITLE
fix(Geometry): ArcAngle fixed

### DIFF
--- a/src/Armorial/Geometry/Arc/Arc.cpp
+++ b/src/Armorial/Geometry/Arc/Arc.cpp
@@ -76,9 +76,11 @@ bool Arc::pointInArc(const Vector2D &point) const {
 }
 
 float Arc::arcAngle() const{
-    float startAngle = (_startAngle.value() < 0) ? _startAngle.value() + M_PI*2 : _startAngle.value();
-    float endAngle = (_endAngle.value() < 0) ? _endAngle.value() + M_PI*2 : _endAngle.value();
-    return std::abs(startAngle - endAngle);
+    float temp = _endAngle.value() - _startAngle.value();
+    if(temp < 0){
+        temp+=M_PI*2;
+    }
+    return temp;
 }
 std::vector<Vector2D> Arc::intersectionWithLine(const LineSegment &lineSegment) const {
     std::vector<Vector2D> intersections;


### PR DESCRIPTION
# What is the proposal of this pull request?
fix a function from Geometry

# What changes have been made?
ArcAngle function from Geometry::Arc was fixed

# How to test this changes?
instantiate an Arc object and get it's internal angle through this function

# References (screenshots, links, etc)

# Checklist
- [x] I have performed a self review on my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
- [x] My changes generated no new warnings

# Additional context
Add any other context or screenshots about this pull request here.
